### PR TITLE
Migration of Handbook docs material to public-facing repository

### DIFF
--- a/docs/conventions/docs/index.rst
+++ b/docs/conventions/docs/index.rst
@@ -1,0 +1,14 @@
+.. _docs:
+
+=============
+Documentation
+=============
+
+.. rubric:: Table of Contents
+
+.. toctree::
+   :maxdepth: 1
+
+   style
+   rst
+   screenshots

--- a/docs/conventions/docs/rst.rst
+++ b/docs/conventions/docs/rst.rst
@@ -1,0 +1,454 @@
+.. _rst:
+
+================
+ReStructuredText
+================
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+
+.. _rst-general:
+
+General
+=======
+
+With the exception of pre-formatted text (e.g., literals and code
+blocks), lines should not exceed 72 characters. At this width, GitHub
+pull request diffs will never be soft wrapped, which aids readability
+and collaboration.
+
+.. TIP::
+
+    Good text editors allow you to set a visual page margin indicator.
+
+Additionally:
+
+* Use spaces, not tabs
+* Lines should end with trailing spaces
+* Files should end with a single empty newline
+
+.. TIP::
+
+    Good text editors can be configured to take care of spaces instead
+    of tabs, trailing spaces, and trailing newlines.
+
+Headings should be preceded by two empty lines to help visually
+distinguish the start of a new section.
+
+Correct:
+
+.. code-block:: rst
+
+    Paragraph belonging to a previous section.
+
+
+    New section header
+    ==================
+
+Incorrect line spacing:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Paragraph belonging to a previous section.
+
+    New section header
+    ==================
+
+In all other cases, with the exception of preformatted text, there
+should never be multiple sequential empty lines.
+
+Correct:
+
+.. code-block:: rst
+
+    Some paragraph text.
+
+    The start of a new paragraph.
+
+Incorrect line spacing:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Some paragraph text.
+
+
+    The start of a new paragraph.
+
+Separate block-level elements with a single empty line.
+
+Correct:
+
+.. code-block:: rst
+
+    Section header
+    ==============
+
+    The first paragraph.
+
+Incorrect line spacing:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Section header
+    ==============
+    The first paragraph.
+
+.. _rst-titles-headings:
+
+Titles and headings
+===================
+
+Use `title case`_ for page titles and `sentence case`_ for headings.
+
+Mark up literals that occur in a title or heading, e.g.:
+
+.. code-block:: rst
+
+    Using ``COPY FROM``
+    ===================
+
+Follow these markup conventions for title and headings:
+
+.. code-block:: rst
+
+    ==========
+    Page Title
+    ==========
+
+    Top-level heading
+    =================
+
+    Second-level heading
+    --------------------
+
+    Third-level heading
+    ~~~~~~~~~~~~~~~~~~~
+
+    Fourth-level heading
+    ^^^^^^^^^^^^^^^^^^^^
+
+    Fifth-level heading
+    ...................
+
+
+.. _rst-labels:
+
+Labels
+======
+
+Page titles and headings should be labeled. Labels must be unique within
+the scope of a single documentation project.
+
+Use ``-`` characters instead of ``_`` characters to separate words in a
+label.
+
+Correct:
+
+.. code-block:: rst
+
+    .. _foo-wigets:
+
+    ===========
+    Foo Widgets
+    ===========
+
+Here, the label for the title is ``foo-widgets``.
+
+Incorrect separating character:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    .. _foo_wigets:
+
+    ===========
+    Foo Widgets
+    ===========
+
+The preferred way to link to documents (from within the same
+documentation project) is to use the most appropriate label as a
+*reference*. For example:
+
+.. code-block:: rst
+
+    Consult the :ref:`foo-widgets` section.
+
+By default, this style of link will use the original title or heading
+text (including case). You can set your own link text, like this:
+
+.. code-block:: rst
+
+    Next, we'll configure a :ref:`foo widget <foo-widgets>`.
+
+.. TIP::
+
+    If you want to link to a page or a subsection of a page but there
+    isn't a corresponding title or heading label, you can add one.
+
+.. NOTE::
+
+    Long labels (20 characters or more) can be unwieldy to use. Opt for
+    a shorthand version of the title or heading if you need to cut
+    things down.
+
+
+.. _lists:
+
+Lists
+=====
+
+
+.. _lists-closed:
+
+Closed
+------
+
+The list items of a :ref:`closed list <style-tips-lists-closed>` appear
+as sequential lines with no additional spacing.
+
+For example:
+
+* Cras at posuere augue
+* Suspendisse quis fermentum quam, at tincidunt nisi
+* Etiam convallis dolor nec dolor feugiat
+
+Closed lists should be marked up using ``*`` characters, with no initial
+space relative to the current indent level, and no spaces between the
+list items.
+
+Correct:
+
+.. code-block:: rst
+
+    Diam vitae:
+
+    * Cras at posuere augue
+    * Suspendisse quis fermentum quam, at tincidunt nisi
+    * Etiam convallis dolor nec dolor feugiat
+
+Incorrect bullets:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Diam vitae:
+
+    - Cras at posuere augue
+    - Suspendisse quis fermentum quam, at tincidunt nisi
+    - Etiam convallis dolor nec dolor feugiat
+
+Incorrect indentation level:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Diam vitae:
+
+     * Cras at posuere augue
+     * Suspendisse quis fermentum quam, at tincidunt nisi
+     * Etiam convallis dolor nec dolor feugiat
+
+Incorrect line spacing:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Diam vitae:
+
+    * Cras at posuere augue
+
+    * Suspendisse quis fermentum quam, at tincidunt nisi
+
+    * Etiam convallis dolor nec dolor feugiat
+
+.. _lists-open:
+
+Open
+----
+
+The list items of an  :ref:`open list <style-tips-lists-open>` appear
+separated like paragraphs.
+
+For example:
+
+.. rst-class:: open
+
+* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
+  tellus, posuere.
+
+* Lacus dolor sit amet tellus. Mauris vel ultrices magna.
+
+  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
+  dolor nec dolor feugiat, non sagittis justo dictum.
+
+* Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
+  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
+  dictum. Etiam eget ornare nibh.
+
+Closed lists should be marked up using ``*`` characters, with no initial
+space relative to the current indent level, and one empty line between
+list items. They must also be prefixed with the ``.. rst-class:: open``
+directive.
+
+Correct:
+
+.. code-block:: rst
+
+    Diam vitae:
+
+    .. rst-class:: open
+
+    * Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
+      tellus, posuere.
+
+    * Lacus dolor sit amet tellus. Mauris vel ultrices magna.
+
+      Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
+      dolor nec dolor feugiat, non sagittis justo dictum.
+
+    * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
+      dictum. Etiam eget ornare nibh.
+
+Missing directive:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Diam vitae:
+
+    * Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
+      tellus, posuere.
+
+    * Lacus dolor sit amet tellus. Mauris vel ultrices magna.
+
+      Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
+      dolor nec dolor feugiat, non sagittis justo dictum.
+
+    * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
+      dictum. Etiam eget ornare nibh.
+
+Incorrect line spacing:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Diam vitae:
+
+    .. rst-class:: open
+
+    * Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
+      tellus, posuere.
+    * Lacus dolor sit amet tellus. Mauris vel ultrices magna.
+
+      Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
+      dolor nec dolor feugiat, non sagittis justo dictum.
+    * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
+      dictum. Etiam eget ornare nibh.
+
+
+.. _indentation:
+
+Indentation
+===========
+
+Literal blocks and admonition blocks should be indented by four
+characters.
+
+Correct:
+
+.. code-block:: rst
+
+    Here's a code example::
+
+        print("Hello world!")
+
+.. code-block:: rst
+
+    Here's a code example:
+
+    .. code-block::
+
+        print("Hello world!")
+
+.. code-block:: rst
+
+    .. NOTE::
+
+        Some note text.
+
+Incorrect indentation level:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    .. NOTE::
+
+       Some note text.
+
+.. _rst-links:
+
+
+Links
+=====
+
+Order link URL lists alphabetically (case-insensitive) and keep them at the end
+of the document.
+
+Links should be listed as a single block and this block should be separated
+from the main text by two empty lines.
+
+Correct:
+
+.. code-block:: rst
+
+    Lorem ipsum dolor sit amet.
+
+
+    .. _Elasticsearch: http://www.elasticsearch.org/
+    .. _Lucene: http://lucene.apache.org/core/
+
+Missing double separator:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Lorem ipsum dolor sit amet.
+
+    .. _Lucene: http://lucene.apache.org/core/
+    .. _Elasticsearch: http://www.elasticsearch.org/
+
+Incorrect separator line between link items:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Lorem ipsum dolor sit amet.
+
+
+    .. _Elasticsearch: http://www.elasticsearch.org/
+
+    .. _Lucene: http://lucene.apache.org/core/
+
+Incorrect sort order:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Lorem ipsum dolor sit amet.
+
+
+    .. _Lucene: http://lucene.apache.org/core/
+    .. _Elasticsearch: http://www.elasticsearch.org/
+
+
+.. _sentence case: https://en.wiktionary.org/wiki/sentence_case
+.. _title case: http://individed.com/code/to-title-case/

--- a/docs/conventions/docs/screenshots.rst
+++ b/docs/conventions/docs/screenshots.rst
@@ -1,0 +1,130 @@
+.. _screenshots:
+
+===========
+Screenshots
+===========
+
+Follow this process to create the best screenshots for technical
+documentation, blog posts, website, and marketing material.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+
+.. _screenshots-os:
+
+Operating system
+================
+
+All screenshots should be taken on the latest edition of macOS, unless
+the screenshot relates to a different specific operating system.
+
+Good:
+
+ - Using macOS to document the visual look of admin UI
+ - Using Windows to document visual look of a CrateDB .NET workflow
+
+Bad:
+
+ - Using Linux to document the visual look of admin UI
+
+.. _screenshots-browser:
+
+Choice of browser
+=================
+
+Unless the choice of browser is important for what you are documenting,
+you should use the standard browser that comes with your operating
+system. For macOS, that is Safari.
+
+
+.. _screenshots-what:
+
+What to include in a screenshot
+===============================
+
+Try to capture an entire window, whether that's the full app window,
+browser window, or something like the window of a modal dialogue box.
+
+Resist the temptation to only take a screenshot of part of a window. If
+you want to draw the reader's attention to a portion of the window,
+instead, add a new paragraph under the screenshot with a verbal
+instruction that directs the reader's attention.
+
+For example:
+
+    "Here, select the *Home* icon from the right-hand side of the top
+    navigation bar."
+
+Good:
+
+* Capturing the full browser window of a web page
+* Capturing only the alert dialogue that pops up when you click some
+  part of the parent app's user interface
+
+Bad:
+
+* Taking a screenshot of an interface and then cropping the image to
+  focus in on a specific part
+
+
+.. _screenshots-size:
+
+Window sizes
+============
+
+Because you will be taking screenshots of a full window, it becomes
+important to size that window properly.
+
+Some general principals:
+
+.. rst-class:: open
+
+* The size of a window should not change.
+
+  If you are taking multiple screenshots of the same window, they should
+  all be taken at exactly the same size. Ideally, this standard size is
+  used throughout the whole documentation project, not just throughout a
+  single page.
+
+* Large windows are good. But not too large. Try to size the window as
+  close as possible to 1280px (width) by 800px (height).
+
+Some tips:
+
+.. rst-class:: open
+
+* You can double check that screenshots of the same window are the same
+  size by loading them in an image preview application and cycling
+  between them.
+
+* If you're taking a screenshot of a browser window, there are plugins
+  (`example`_) that resize the window to a size of your choosing. You
+  can use a plugin like this to ensure a consistent size.
+
+* On macOS, do not maximize the window into a new space. This hides the
+  standard window `chrome`_ (e.g., the red, yellow, and green dots in
+  the title bar), which is an important component of the screenshot.
+
+  To better maximize a window, hold down *Option (⌥)* as you click the
+  blue button in the window title bar.
+
+
+.. _screenshots-shadow:
+
+Drop shadows
+============
+
+By default, macOS includes a drop shadow when creating a screenshot.
+Avoid this. Take a screenshot *without* a drop shadow. Like so:
+
+ * Press *Command (⌘)-Shift (⇧)-4*
+ * Press *Spacebar*
+ * Hold down *Option (⌥)*
+ * Click the window you want to screenshot
+
+
+.. _chrome: https://www.nngroup.com/articles/browser-and-gui-chrome/
+.. _example: https://mehlau.net/resizewindow/

--- a/docs/conventions/docs/style.rst
+++ b/docs/conventions/docs/style.rst
@@ -1,0 +1,218 @@
+.. _style-guide:
+
+===========
+Style Guide
+===========
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+
+.. _style-general:
+
+General
+=======
+
+We use standard `American English`_.
+
+Unless otherwise specified, we follow `The Chicago Manual of Style`_.
+
+.. TIP::
+
+    We have a company login for the online version of the Chicago Manual
+    of Style. If you need to access it, please ask a technical writer
+    for help.
+
+
+.. _style-tips:
+
+Tips
+====
+
+
+.. _style-tips-punc:
+
+Punctuation
+-----------
+
+
+.. _style-tips-spaces:
+
+Spaces
+~~~~~~
+
+Do not use double spaces after a period.
+
+Correct:
+
+.. code-block:: rst
+
+
+    This is the standard theme. The community edition of CrateDB uses a
+    lighter theme.
+
+Incorrect double space:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    This is the standard theme.  The community edition of CrateDB uses a
+    lighter theme.
+
+
+.. _style-tips-commas:
+
+Commas
+~~~~~~
+
+We use the `serial commas`_.
+
+Correct:
+
+.. code-block:: rst
+
+    CrateDB provides flexibility, scalability, and ease-of-use.
+
+Missing serial comma:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    CrateDB provides flexibility, scalability and ease-of-use.
+
+Lists should always include the word "and" after the seral comma, even
+in headings.
+
+Correct:
+
+.. code-block:: rst
+
+    Insert, Update, and Delete
+    ==========================
+
+Missing word:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Insert, Update, Delete
+    ======================
+
+
+.. _style-tips-lists:
+
+Lists
+-----
+
+
+.. _style-tips-lists-closed:
+
+Closed
+~~~~~~
+
+Use :ref:`closed lists <lists-closed>` for simple lists:
+
+* Cras at posuere augue
+* Suspendisse quis fermentum quam, at tincidunt nisi
+* Etiam convallis dolor nec dolor feugiat
+
+Typically, each list item will be a single sentence and terminal
+punctuation is not used.
+
+
+.. _style-tips-lists-open:
+
+Open
+~~~~
+
+Use :ref:`open lists <lists-open>` for more complex list items:
+
+.. rst-class:: open
+
+* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
+  tellus, posuere.
+
+* Lacus dolor sit amet tellus. Mauris vel ultrices magna.
+
+  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
+  dolor nec dolor feugiat, non sagittis justo dictum.
+
+* Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
+  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
+  dictum. Etiam eget ornare nibh.
+
+Open lists are useful because paragraph spacing makes longer blocks of
+text easier to read. Terminal punctuation is used.
+
+
+.. _style-tips-numbers:
+
+Numbering
+---------
+
+Numbers under 10 should be spelled out, unless they're literals (i.e.,
+SQL, configuration examples, code, etc.). For example, write "three",
+and not "3".
+
+.. NOTE::
+
+    You can make an exception if you are enumerating a list. For
+    example: "Step 1" works better than "Step One".
+
+Write "Third" and not "3rd", or similar.
+
+Numbers 10 or over should be written using numerals (i.e., "10", and not
+"ten").
+
+
+.. _style-tips-misc:
+
+Miscellaneous
+-------------
+
+The term "ID" is an abbreviation and should always be capitalised in
+prose. Lowercase is okay for literals, such as column names or variables
+(e.g., ``row_id``).
+
+Use "and" instead of "&".
+
+Do not use "/" (a solidus) where an "and" or "or" will do. You should
+restructure your sentence accordingly.
+
+Correct:
+
+.. code-block:: rst
+
+    Unsupported Features and Functions
+    ==================================
+
+.. code-block:: rst
+
+    Inner Objects and Nested Objects
+    ================================
+
+Incorrect use of a solidus:
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Unsupported Features / Functions
+    ================================
+
+.. rst-class:: incorrect
+.. code-block:: rst
+
+    Inner/Nested Objects
+    ====================
+
+.. NOTE::
+
+    You can make an exception if using "/" is in accordance with common
+    usage (e.g., "client/server").
+
+
+.. _American English: https://en.wikipedia.org/wiki/American_English
+.. _serial commas: https://en.wikipedia.org/wiki/Serial_comma
+.. _The Chicago Manual of Style: https://www.chicagomanualofstyle.org/home.html

--- a/docs/conventions/index.rst
+++ b/docs/conventions/index.rst
@@ -1,0 +1,34 @@
+.. _conventions:
+
+===========
+Conventions
+===========
+
+Consistency makes collaboration easier. To that end, please try to
+follow the applicable conventions.
+
+We have two core principals:
+
+.. rst-class:: open
+
+1. Don't follow a convention if it means introducing local
+   inconsistencies. Consistency within a project is important. Consistency
+   within a file is more important. Consistency within a logical subsection
+   of a file is the most important.
+
+2. Know when to be inconsistent. Break any of these conventions sooner
+   than doing anything foolish.
+
+.. NOTE::
+
+    Please help us to develop this section of the handbook! At the
+    moment, we only have guides for the documentation. But we could
+    probably do with guides for software development, infrastructure,
+    and so on.
+
+.. rubric:: Table of Contents
+
+.. toctree::
+   :maxdepth: 2
+
+   docs/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,4 +2,18 @@
 Crate Docs Utils
 ================
 
-This documentation is a stub.
+This repository currently contains support for the Docs-Utils tools, used for
+testing the validity and correctness of documentation. We are currently
+migrating other docs-related materials that should be public to it, so it can
+serve in the near future as the base for all materials concerning the docs.
+Since our documentation is open source, we want to enable external contributors
+by making supporting materials (such as our conventions and style guide)
+publicly available.
+
+
+.. rubric:: Table of Contents
+
+.. toctree::
+   :maxdepth: 2
+
+   conventions/index


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Migration of docs-related material (conventions, style guide etc.) to the crate-docs-utils repo, which is intended to become the public facing repository for docs stuff. The aim is that external contributors know all the guidelines for docs publishing on Crate.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
