### PR TITLE
Fixes style conformity of style guide and adds WP screenshot tutorial

### DIFF
--- a/docs/conventions/docs/rst.rst
+++ b/docs/conventions/docs/rst.rst
@@ -15,10 +15,10 @@ ReStructuredText
 General
 =======
 
-With the exception of pre-formatted text (e.g., literals and code
-blocks), lines should not exceed 72 characters. At this width, GitHub
-pull request diffs will never be soft wrapped, which aids readability
-and collaboration.
+With the exception of pre-formatted text (e.g., literals and code blocks), as
+well as link URLs, lines should not exceed 79 characters. They should be
+wrapped as closely to 79 characters per line as possible, without exceeding
+that limit.
 
 .. TIP::
 
@@ -32,11 +32,11 @@ Additionally:
 
 .. TIP::
 
-    Good text editors can be configured to take care of spaces instead
-    of tabs, trailing spaces, and trailing newlines.
+    Good text editors can be configured to take care of spaces instead of tabs,
+    trailing spaces, and trailing newlines.
 
-Headings should be preceded by two empty lines to help visually
-distinguish the start of a new section.
+Headings should be preceded by two empty lines to help visually distinguish the
+start of a new section.
 
 Correct:
 
@@ -58,8 +58,8 @@ Incorrect line spacing:
     New section header
     ==================
 
-In all other cases, with the exception of preformatted text, there
-should never be multiple sequential empty lines.
+In all other cases, with the exception of preformatted text, there should never
+be multiple sequential empty lines.
 
 Correct:
 
@@ -142,11 +142,10 @@ Follow these markup conventions for title and headings:
 Labels
 ======
 
-Page titles and headings should be labeled. Labels must be unique within
-the scope of a single documentation project.
+Page titles and headings should be labeled. Labels must be unique within the
+scope of a single documentation project.
 
-Use ``-`` characters instead of ``_`` characters to separate words in a
-label.
+Use ``-`` characters instead of ``_`` characters to separate words in a label.
 
 Correct:
 
@@ -171,16 +170,15 @@ Incorrect separating character:
     Foo Widgets
     ===========
 
-The preferred way to link to documents (from within the same
-documentation project) is to use the most appropriate label as a
-*reference*. For example:
+The preferred way to link to documents (from within the same documentation
+project) is to use the most appropriate label as a *reference*. For example:
 
 .. code-block:: rst
 
     Consult the :ref:`foo-widgets` section.
 
-By default, this style of link will use the original title or heading
-text (including case). You can set your own link text, like this:
+By default, this style of link will use the original title or heading text
+(including case). You can set your own link text, like this:
 
 .. code-block:: rst
 
@@ -188,14 +186,13 @@ text (including case). You can set your own link text, like this:
 
 .. TIP::
 
-    If you want to link to a page or a subsection of a page but there
-    isn't a corresponding title or heading label, you can add one.
+    If you want to link to a page or a subsection of a page but there isn't a
+    corresponding title or heading label, you can add one.
 
 .. NOTE::
 
-    Long labels (20 characters or more) can be unwieldy to use. Opt for
-    a shorthand version of the title or heading if you need to cut
-    things down.
+    Long labels (20 characters or more) can be unwieldy to use. Opt for a
+    shorthand version of the title or heading if you need to cut things down.
 
 
 .. _lists:
@@ -209,8 +206,8 @@ Lists
 Closed
 ------
 
-The list items of a :ref:`closed list <style-tips-lists-closed>` appear
-as sequential lines with no additional spacing.
+The list items of a :ref:`closed list <style-tips-lists-closed>` appear as
+sequential lines with no additional spacing.
 
 For example:
 
@@ -218,9 +215,8 @@ For example:
 * Suspendisse quis fermentum quam, at tincidunt nisi
 * Etiam convallis dolor nec dolor feugiat
 
-Closed lists should be marked up using ``*`` characters, with no initial
-space relative to the current indent level, and no spaces between the
-list items.
+Closed lists should be marked up using ``*`` characters, with no initial space
+relative to the current indent level, and no spaces between the list items.
 
 Correct:
 
@@ -272,29 +268,28 @@ Incorrect line spacing:
 Open
 ----
 
-The list items of an  :ref:`open list <style-tips-lists-open>` appear
-separated like paragraphs.
+The list items of an  :ref:`open list <style-tips-lists-open>` appear separated
+like paragraphs.
 
 For example:
 
 .. rst-class:: open
 
-* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
-  tellus, posuere.
+* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim tellus,
+  posuere.
 
 * Lacus dolor sit amet tellus. Mauris vel ultrices magna.
 
-  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
-  dolor nec dolor feugiat, non sagittis justo dictum.
+  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis dolor nec
+  dolor feugiat, non sagittis justo dictum.
 
 * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
-  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
-  dictum. Etiam eget ornare nibh.
+  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna dictum. Etiam
+  eget ornare nibh.
 
-Closed lists should be marked up using ``*`` characters, with no initial
-space relative to the current indent level, and one empty line between
-list items. They must also be prefixed with the ``.. rst-class:: open``
-directive.
+Closed lists should be marked up using ``*`` characters, with no initial space
+relative to the current indent level, and one empty line between list items.
+They must also be prefixed with the ``.. rst-class:: open`` directive.
 
 Correct:
 
@@ -313,8 +308,8 @@ Correct:
       dolor nec dolor feugiat, non sagittis justo dictum.
 
     * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
-      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
-      dictum. Etiam eget ornare nibh.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna dictum.
+      Etiam eget ornare nibh.
 
 Missing directive:
 
@@ -332,8 +327,8 @@ Missing directive:
       dolor nec dolor feugiat, non sagittis justo dictum.
 
     * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
-      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
-      dictum. Etiam eget ornare nibh.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna dictum.
+      Etiam eget ornare nibh.
 
 Incorrect line spacing:
 
@@ -351,8 +346,8 @@ Incorrect line spacing:
       Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
       dolor nec dolor feugiat, non sagittis justo dictum.
     * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
-      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
-      dictum. Etiam eget ornare nibh.
+      Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna dictum.
+      Etiam eget ornare nibh.
 
 
 .. _indentation:
@@ -360,8 +355,7 @@ Incorrect line spacing:
 Indentation
 ===========
 
-Literal blocks and admonition blocks should be indented by four
-characters.
+Literal blocks and admonition blocks should be indented by four characters.
 
 Correct:
 

--- a/docs/conventions/docs/screenshots.rst
+++ b/docs/conventions/docs/screenshots.rst
@@ -4,8 +4,8 @@
 Screenshots
 ===========
 
-Follow this process to create the best screenshots for technical
-documentation, blog posts, website, and marketing material.
+Follow this process to create the best screenshots for technical documentation,
+blog posts, website, and marketing material.
 
 .. rubric:: Table of Contents
 
@@ -13,18 +13,24 @@ documentation, blog posts, website, and marketing material.
    :local:
 
 
+.. _screenshots-general:
+
+General instructions
+====================
+
+
 .. _screenshots-os:
 
 Operating system
-================
+----------------
 
-All screenshots should be taken on the latest edition of macOS, unless
-the screenshot relates to a different specific operating system.
+All screenshots should be taken on the latest edition of macOS, unless the
+screenshot relates to a different specific operating system.
 
 Good:
 
  - Using macOS to document the visual look of admin UI
- - Using Windows to document visual look of a CrateDB .NET workflow
+ - Using Windows to document the visual look of a CrateDB .NET workflow
 
 Bad:
 
@@ -33,25 +39,25 @@ Bad:
 .. _screenshots-browser:
 
 Choice of browser
-=================
+-----------------
 
-Unless the choice of browser is important for what you are documenting,
-you should use the standard browser that comes with your operating
-system. For macOS, that is Safari.
+Unless the choice of browser is important for what you are documenting, you
+should use the standard browser that comes with your operating system. For
+macOS, that is Safari.
 
 
 .. _screenshots-what:
 
 What to include in a screenshot
-===============================
+-------------------------------
 
-Try to capture an entire window, whether that's the full app window,
-browser window, or something like the window of a modal dialogue box.
+Try to capture an entire window, whether that's the full app window, browser
+window, or something like the window of a modal dialogue box.
 
-Resist the temptation to only take a screenshot of part of a window. If
-you want to draw the reader's attention to a portion of the window,
-instead, add a new paragraph under the screenshot with a verbal
-instruction that directs the reader's attention.
+Resist the temptation to only take a screenshot of part of a window. If you
+want to draw the reader's attention to a portion of the window, instead, add a
+new paragraph under the screenshot with a verbal instruction that directs the
+reader's attention.
 
 For example:
 
@@ -73,57 +79,86 @@ Bad:
 .. _screenshots-size:
 
 Window sizes
-============
+------------
 
-Because you will be taking screenshots of a full window, it becomes
-important to size that window properly.
+Because you will be taking screenshots of a full window, it becomes important
+to size that window properly.
 
-Some general principals:
+Some general principles:
 
 .. rst-class:: open
 
 * The size of a window should not change.
 
-  If you are taking multiple screenshots of the same window, they should
-  all be taken at exactly the same size. Ideally, this standard size is
-  used throughout the whole documentation project, not just throughout a
-  single page.
+  If you are taking multiple screenshots of the same window, they should all be
+  taken at exactly the same size. Ideally, this standard size is used
+  throughout the whole documentation project, not just throughout a single
+  page.
 
-* Large windows are good. But not too large. Try to size the window as
-  close as possible to 1280px (width) by 800px (height).
+* Large windows are good. But not too large. Try to size the window as close as
+  possible to 1280px (width) by 800px (height).
 
 Some tips:
 
 .. rst-class:: open
 
-* You can double check that screenshots of the same window are the same
-  size by loading them in an image preview application and cycling
-  between them.
+* You can double check that screenshots of the same window are the same size by
+  loading them in an image preview application and cycling between them.
 
 * If you're taking a screenshot of a browser window, there are plugins
-  (`example`_) that resize the window to a size of your choosing. You
-  can use a plugin like this to ensure a consistent size.
+  (`example`_) that resize the window to a size of your choosing. You can use a
+  plugin like this to ensure a consistent size.
 
 * On macOS, do not maximize the window into a new space. This hides the
-  standard window `chrome`_ (e.g., the red, yellow, and green dots in
-  the title bar), which is an important component of the screenshot.
+  standard window `chrome`_ (e.g., the red, yellow, and green dots in the title
+  bar), which is an important component of the screenshot.
 
-  To better maximize a window, hold down *Option (⌥)* as you click the
-  blue button in the window title bar.
+  To better maximize a window, hold down *Option (⌥)* as you click the blue
+  button in the window title bar.
 
 
 .. _screenshots-shadow:
 
 Drop shadows
-============
+------------
 
-By default, macOS includes a drop shadow when creating a screenshot.
-Avoid this. Take a screenshot *without* a drop shadow. Like so:
+By default, macOS includes a drop shadow when creating a screenshot. This is
+correct for screenshots. If necessary, enable drop shadows.
 
- * Press *Command (⌘)-Shift (⇧)-4*
- * Press *Spacebar*
- * Hold down *Option (⌥)*
- * Click the window you want to screenshot
+
+.. _screenshots-blog:
+
+Screenshots for blog publishing
+===============================
+
+For publishing on the Crate.io blog via Wordpress, we provide a step-by-step
+guide that gives the best results. Following these instructions is helpful
+because otherwise images tend to come out blurry due to the different
+appearance of images on Retina devices (i.e., modern Apple ones) and non-Retina
+devices.
+
+.. rst-class:: open
+
+* Adjust your display resolution to show the largest text. This is usually
+  achieved by making your resolution as low as possible. This will help keep
+  screenshots legible when resized.
+
+* Use the OS-default browser and set it as close as possible to default
+  settings, for example by opening an anonymous tab.
+
+* Take screenshots maximized to the full size of the screen, *without* using
+  'full screen' mode.
+
+* Keep drop shadows enabled.
+
+* Upload the screenshots to our Wordpress.
+
+* Insert the screenshot in the raw HTML editor (not the text editor).
+
+* Remove the ``width`` and ``height`` attributes of the ``<img>`` tags.
+
+* Finally, also remove the width and height info from the URL generated for the
+  screenshots by Wordpress.
 
 
 .. _chrome: https://www.nngroup.com/articles/browser-and-gui-chrome/

--- a/docs/conventions/docs/style.rst
+++ b/docs/conventions/docs/style.rst
@@ -21,9 +21,8 @@ Unless otherwise specified, we follow `The Chicago Manual of Style`_.
 
 .. TIP::
 
-    We have a company login for the online version of the Chicago Manual
-    of Style. If you need to access it, please ask a technical writer
-    for help.
+    We have a company login for the online version of the Chicago Manual of
+    Style. If you need to access it, please ask a technical writer for help.
 
 
 .. _style-tips:
@@ -50,8 +49,8 @@ Correct:
 .. code-block:: rst
 
 
-    This is the standard theme. The community edition of CrateDB uses a
-    lighter theme.
+    This is the standard theme. The community edition of CrateDB uses a lighter
+    theme.
 
 Incorrect double space:
 
@@ -67,7 +66,7 @@ Incorrect double space:
 Commas
 ~~~~~~
 
-We use the `serial commas`_.
+We use `serial commas`_.
 
 Correct:
 
@@ -82,8 +81,8 @@ Missing serial comma:
 
     CrateDB provides flexibility, scalability and ease-of-use.
 
-Lists should always include the word "and" after the seral comma, even
-in headings.
+Lists should always include the word "and" after the serial comma, even in
+headings.
 
 Correct:
 
@@ -118,8 +117,8 @@ Use :ref:`closed lists <lists-closed>` for simple lists:
 * Suspendisse quis fermentum quam, at tincidunt nisi
 * Etiam convallis dolor nec dolor feugiat
 
-Typically, each list item will be a single sentence and terminal
-punctuation is not used.
+Typically, each list item will be a single sentence and terminal punctuation is
+not used.
 
 
 .. _style-tips-lists-open:
@@ -131,20 +130,20 @@ Use :ref:`open lists <lists-open>` for more complex list items:
 
 .. rst-class:: open
 
-* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim
-  tellus, posuere.
+* Integer faucibus, nisl non hendrerit maximus, purus massa dignissim tellus,
+  posuere.
 
 * Lacus dolor sit amet tellus. Mauris vel ultrices magna.
 
-  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis
-  dolor nec dolor feugiat, non sagittis justo dictum.
+  Suspendisse quis fermentum quam, at tincidunt nisi. Etiam convallis dolor nec
+  dolor feugiat, non sagittis justo dictum.
 
 * Nullam scelerisque lectus orci, nec rhoncus libero sollicitudin nec.
-  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna
-  dictum. Etiam eget ornare nibh.
+  Suspendisse dictum eros eu dui lacinia, vitae ullamcorper magna dictum. Etiam
+  eget ornare nibh.
 
-Open lists are useful because paragraph spacing makes longer blocks of
-text easier to read. Terminal punctuation is used.
+Open lists are useful because paragraph spacing makes longer blocks of text
+easier to read. Terminal punctuation is used.
 
 
 .. _style-tips-numbers:
@@ -152,19 +151,17 @@ text easier to read. Terminal punctuation is used.
 Numbering
 ---------
 
-Numbers under 10 should be spelled out, unless they're literals (i.e.,
-SQL, configuration examples, code, etc.). For example, write "three",
-and not "3".
+Numbers under 10 should be spelled out, unless they're literals (i.e., SQL,
+configuration examples, code, etc.). For example, write "three", not "3".
 
 .. NOTE::
 
-    You can make an exception if you are enumerating a list. For
-    example: "Step 1" works better than "Step One".
+    You can make an exception if you are enumerating a list. For example:
+    "Step 1" works better than "Step One".
 
-Write "Third" and not "3rd", or similar.
+Write "third" and not "3rd", or similar.
 
-Numbers 10 or over should be written using numerals (i.e., "10", and not
-"ten").
+Numbers 10 or over should be written using numerals (i.e., "10", not "ten").
 
 
 .. _style-tips-misc:
@@ -172,9 +169,9 @@ Numbers 10 or over should be written using numerals (i.e., "10", and not
 Miscellaneous
 -------------
 
-The term "ID" is an abbreviation and should always be capitalised in
-prose. Lowercase is okay for literals, such as column names or variables
-(e.g., ``row_id``).
+The term "ID" is an abbreviation and should always be capitalized in prose.
+Lowercase is okay for literals, such as column names or variables (e.g.,
+``row_id``).
 
 Use "and" instead of "&".
 
@@ -209,8 +206,8 @@ Incorrect use of a solidus:
 
 .. NOTE::
 
-    You can make an exception if using "/" is in accordance with common
-    usage (e.g., "client/server").
+    You can make an exception if using "/" is in accordance with common usage
+    (e.g., "client/server").
 
 
 .. _American English: https://en.wikipedia.org/wiki/American_English

--- a/docs/conventions/index.rst
+++ b/docs/conventions/index.rst
@@ -4,27 +4,26 @@
 Conventions
 ===========
 
-Consistency makes collaboration easier. To that end, please try to
-follow the applicable conventions.
+Consistency makes collaboration easier. To that end, please try to follow the
+applicable conventions.
 
-We have two core principals:
+We have two core principles:
 
 .. rst-class:: open
 
-1. Don't follow a convention if it means introducing local
-   inconsistencies. Consistency within a project is important. Consistency
-   within a file is more important. Consistency within a logical subsection
-   of a file is the most important.
+1. Don't follow a convention if it means introducing local inconsistencies.
+   Consistency within a project is important. Consistency within a file is more
+   important. Consistency within a logical subsection of a file is the most
+   important.
 
-2. Know when to be inconsistent. Break any of these conventions sooner
-   than doing anything foolish.
+2. Know when to be inconsistent. Break any of these conventions sooner than
+   doing anything foolish.
 
 .. NOTE::
 
-    Please help us to develop this section of the handbook! At the
-    moment, we only have guides for the documentation. But we could
-    probably do with guides for software development, infrastructure,
-    and so on.
+    Please help us to develop this section of the handbook! At the moment, we
+    only have guides for the documentation. But we could probably do with
+    guides for software development, infrastructure, and so on.
 
 .. rubric:: Table of Contents
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The style guide and conventions sections of our (newly migrated) docs instructions do not themselves correspond to the style guide and conventions! Awkward! This PR fixes that. It also adds the step-by-step guide for making screenshots that don't look blurry in Wordpress. Currently this guide is only in the Tech Writing Trello board, which is inconvenient. (It may be of
later use for possible guest contributors to the blog, too.)

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
